### PR TITLE
Add callback path for microsoft

### DIFF
--- a/src/App_Start/UmbracoMicrosoftAuthExtensions.cs
+++ b/src/App_Start/UmbracoMicrosoftAuthExtensions.cs
@@ -46,7 +46,8 @@ namespace $rootnamespace$
             {
                 ClientId = clientId,
                 ClientSecret = clientSecret,
-                SignInAsAuthenticationType = Constants.Security.BackOfficeExternalAuthenticationType
+                SignInAsAuthenticationType = Constants.Security.BackOfficeExternalAuthenticationType,
+                CallbackPath = new PathString("/umbraco-microsoft-signin")
             };
             msOptions.ForUmbracoBackOffice(style, icon);
             msOptions.Caption = caption;


### PR DESCRIPTION
I had to add this so that the redirect URL was picked up for authentication. This matches what is done for Google and Facebook so not sure why it wasn't included for Microsoft.