### PR TITLE
Reorder the standard owin startup sample to fix preview problems.

### DIFF
--- a/src/Umbraco.IdentityExtensions/App_Start/UmbracoStandardOwinStartup.cs.pp
+++ b/src/Umbraco.IdentityExtensions/App_Start/UmbracoStandardOwinStartup.cs.pp
@@ -24,9 +24,6 @@ namespace $rootnamespace$
         /// <param name="app"></param>
         protected override void ConfigureUmbracoAuthentication(IAppBuilder app)
         {
-            // Must call the base implementation to configure the default back office authentication config.
-            base.ConfigureUmbracoAuthentication(app);
-
             /* 
             * Configure external logins for the back office:
             * 
@@ -67,6 +64,11 @@ namespace $rootnamespace$
              *                  }
              *              });
              */
+
+            // Must call the base implementation to configure the default back office authentication config.
+            // This must be done last.
+            base.ConfigureUmbracoAuthentication(app);
+
         }
     }
 }

--- a/src/Umbraco.IdentityExtensions/App_Start/UmbracoStandardOwinStartup.cs.pp
+++ b/src/Umbraco.IdentityExtensions/App_Start/UmbracoStandardOwinStartup.cs.pp
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Owin;
 using Owin;
 using Umbraco.Web;
+using Umbraco.Web.Security;
 using $rootnamespace$;
 
 //To use this startup class, change the appSetting value in the web.config called 
@@ -24,6 +25,9 @@ namespace $rootnamespace$
         /// <param name="app"></param>
         protected override void ConfigureUmbracoAuthentication(IAppBuilder app)
         {
+            // Must call the base implementation to configure the default back office authentication config.
+            base.ConfigureUmbracoAuthentication(app);
+
             /* 
             * Configure external logins for the back office:
             * 
@@ -48,6 +52,8 @@ namespace $rootnamespace$
              * By default the CORS policy is to allow all requests
              * 
              *      app.UseUmbracoBackOfficeTokenAuth(new BackOfficeAuthServerProviderOptions());
+             *      // you have to configure preview authentication after the token server
+             *      app.UseUmbracoPreviewAuthentication(UmbracoContextAccessor, RuntimeState, GlobalSettings, UmbracoSettings.Security, PipelineStage.Authorize);
              *      
              * If you want to have a custom CORS policy for the token server you can provide
              * a custom CORS policy, example: 
@@ -65,9 +71,6 @@ namespace $rootnamespace$
              *              });
              */
 
-            // Must call the base implementation to configure the default back office authentication config.
-            // This must be done last.
-            base.ConfigureUmbracoAuthentication(app);
 
         }
     }


### PR DESCRIPTION
Reorder the standard startup sample so `base.Configuration(app);` occurs last, ensuring preview doesn't break.